### PR TITLE
Changes for using fakeTDL with products

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,17 @@ daffodilFlatLayout := true
 
 daffodilVersion := daffodilPackageBinVersions.value.head
 
-daffodilPackageBinVersions := Seq("3.9.0", "3.8.0", "3.7.0", "3.5.0")
+libraryDependencies ++= Seq(
+  "com.owlcyberdefense" % "dfdl-test-harness" % "0.0.1",
+)
+
+daffodilPackageBinVersions := Seq("3.9.0", "3.8.0", "3.7.0", "3.5.0", "3.4.0", "3.3.0")
 
 daffodilPackageBinInfos := Seq(
   // schema for a single message
   DaffodilBinInfo("/fakeTDL.dfdl.xsd", root = Some("fakeTDL"), name = Some("fakeTDL")),
+  // schema for a file of messages with metadata
+  DaffodilBinInfo("/fakeTDLWithMetadata.dfdl.xsd", root = Some("fakeTDLWithMetadata"), name = Some("fakeTDLWithMetadata")),
   // schema for a file of messages
   DaffodilBinInfo("/fakeTDL.dfdl.xsd", root = Some("fakeTDLFile"), name = Some("fakeTDLFile"))
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.1.0")
+addSbtPlugin("com.owlcyberdefense" % "sbt-flowerpress" % "1.0.0")

--- a/src/fakeTDLWithMetadata.dfdl.xsd
+++ b/src/fakeTDLWithMetadata.dfdl.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:meta="urn:com.owlcyberdefense.dfdl-test-harness"
+  xmlns:fakeTDL="urn:com.owlcyberdefense.fakeTDL">
+  <!--
+  This schema has no target namespace on purpose.
+
+  It defines a reusable fakeTDL element which can be used directly for testing or
+  incorporated into a larger structure via an element reference.
+
+  It also defines a fakeTDLFile element which is primarily for testing and allows
+  parsing and unparsing files containing many fakeTDL messages.
+
+  Note that a schema with no target namespace cannot have a default namespace definition.
+  That means you can't get away with avoiding the need for the "xs:" prefixes on all
+  the XSD/DFDL keywords in a no-target-namespace schema. As a result, it's best for these
+  no-namespace schemas that define global elements to be kept as small as possible.
+
+  Hence, schema files that define global elements should *only* define global elements.
+  Other definitions of the types/groups used, should go in an imported schema file
+  which has a namespace.
+  -->
+
+  <xs:import namespace="urn:com.owlcyberdefense.fakeTDL" schemaLocation="fakeTDLType.dfdl.xsd" />
+  <xs:import namespace="urn:com.owlcyberdefense.dfdl-test-harness" schemaLocation="/com/owlcyberdefense/dfdl-test-harness/xsd/MetadataHeader.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="fakeTDL:fakeTDL-base"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="fakeTDLWithMetadata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="metadata" type="meta:MetadataHeader"/>
+        <xs:element name="fakeTDL" type="fakeTDL:fakeTDLType" dfdl:ref="fakeTDL:fakeTDL-fixedLengthMessage" minOccurs="1" maxOccurs="1000" dfdl:occursCountKind="implicit"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
Needed to broaden the range of supported Daffodil versions to work with some of our products.

Also includes an envelope schema for the dfdl-test-harness that includes some basic metadata for measuring performance