### PR TITLE
Version 1.0.1 update to Daffodil 3.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-fakeTDL"
 
 organization := "com.owlcyberdefense"
 
-version := "1.0.0"
+version := "1.0.1"
 
 // for details about DaffodilPlugin settings, see https://github.com/apache/daffodil-sbt
 enablePlugins(DaffodilPlugin)
@@ -11,7 +11,7 @@ daffodilFlatLayout := true
 
 daffodilVersion := daffodilPackageBinVersions.value.head
 
-daffodilPackageBinVersions := Seq("3.9.0", "3.8.0", "3.7.0", "3.5.0")
+daffodilPackageBinVersions := Seq("3.10.0", "3.9.0", "3.8.0", "3.7.0", "3.5.0", "3.4.0")
 
 daffodilPackageBinInfos := Seq(
   // schema for a single message

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.1.0")
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.+")


### PR DESCRIPTION
Also changed daffodil-sbt plugin to "1.+" so that the next version of daffodil-sbt will be used once it is published.