### PR TITLE
Version 1.0.2 use dfdlx:lookAhead() avoids messageType element

### DIFF
--- a/FakeTDLSpecification.md
+++ b/FakeTDLSpecification.md
@@ -77,7 +77,7 @@ are filled with 0x53 (which corresponds to ASCII 'X' if you look at raw data as 
 
 All messages start with these fields:
 
-- messageType - 1 character (T, D, or A for Track, IDentity, and Ack)
+- messageType - 1 character tag (T, D, or A for Track, IDentity, and Ack)
 - source unit number - originator of the message (5 characters)
 - message send time - time of day. Note that 
   message send time is distinguished from the time an observation was made. 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-fakeTDL"
 
 organization := "com.owlcyberdefense"
 
-version := "1.0.1"
+version := "1.0.2"
 
 // for details about DaffodilPlugin settings, see https://github.com/apache/daffodil-sbt
 enablePlugins(DaffodilPlugin)

--- a/src/fakeTDL-field-types.dfdl.xsd
+++ b/src/fakeTDL-field-types.dfdl.xsd
@@ -33,17 +33,6 @@
     </appinfo>
   </annotation>
 
-  <simpleType name="messageType"
-              dfdl:lengthKind="implicit">
-    <restriction base="xs:string" >
-      <minLength value="1"/>
-      <maxLength value="1"/>
-      <enumeration value="T"/><!-- Track -->
-      <enumeration value="D"/><!-- D for iDentity -->
-      <enumeration value="A"/><!-- Ack -->
-    </restriction>
-  </simpleType>
-
   <simpleType name="unitNumber"
               dfdl:lengthKind="implicit">
     <restriction base="xs:string">

--- a/src/fakeTDLType.dfdl.xsd
+++ b/src/fakeTDLType.dfdl.xsd
@@ -5,6 +5,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:fakeTDL="urn:com.owlcyberdefense.fakeTDL"
   targetNamespace="urn:com.owlcyberdefense.fakeTDL">
 
@@ -43,17 +44,31 @@
 
   <complexType name="fakeTDLType">
     <sequence>
-      <element name="messageType" type="fakeTDL:messageType"/>
-      <choice dfdl:choiceDispatchKey="{ messageType }">
-        <element name="track" type="fakeTDL:trackMessageType" dfdl:choiceBranchKey="T"/>
-        <element name="identity" type="fakeTDL:identityMessageType" dfdl:choiceBranchKey="D"/>
-        <element name="ack" type="fakeTDL:ackMessageType" dfdl:choiceBranchKey="A"/>
+      <!--
+      We would really like to make the choice below use dfdl:initiatedContent="yes"
+      with each choice branch having a distinct 1-character dfdl:initiator.
+      But unfortunately, Daffodil 3.10.0 and prior do not optimize this into a
+      constant-time dispatch. Rather, it will try each branch in sequence, which
+      is linear in the number of branches. We only have 3, but in a real TDL
+      there would be dozens of message types.
+
+      So instead we use a choice-by-dispatch, which is constant time, but
+      we use a Daffodil extension of DFDL: the dfdlx:lookAhead() function.
+      -->
+      <choice dfdl:choiceDispatchKey="{ xs:string(dfdlx:lookAhead(0, 8)) }">
+        <!--
+        In the above choiceDispatchKey expression, it would be nice if DFDL or Daffodil provided
+        a way to convert this lookAhead() integer value to a character (T, D, or A) based on Unicode codepoint values.
+        But there is no such iToA-like function in DFDL v1.0 nor Daffodil extensions (as of Daffodil 3.10.0 and prior)
+        so we have to just use the ascii code as a decimal number for the choice dispatch.
+        -->
+        <element name="track" type="fakeTDL:trackMessageType" dfdl:initiator="T" dfdl:choiceBranchKey="84"/>
+        <element name="identity" type="fakeTDL:identityMessageType" dfdl:initiator="D" dfdl:choiceBranchKey="68"/>
+        <element name="ack" type="fakeTDL:ackMessageType" dfdl:initiator="A" dfdl:choiceBranchKey="65"/>
         <!--
         dfdl:choiceDispatchKey selects the branch with the matching dfdl:choiceBranchKey
         in constant time (using a hash table lookup). It avoids any point of uncertainty
-        in the parsing.
-
-        So this is the technique to use if there are a large number of message types.
+        in the parsing. So this is the technique of choice in Daffodil (as of 3.10.0 or prior version).
         -->
       </choice>
     </sequence>

--- a/test/TestFakeTDL.tdml
+++ b/test/TestFakeTDL.tdml
@@ -53,7 +53,6 @@ but they are commonly needed so we have them here for future convenience.
     <infoset>
       <dfdlInfoset>
         <fakeTDL xmlns=""> <!-- Trick! Turn off default namespace. That's what xmlns="" does. -->
-          <messageType>T</messageType>
           <track>
             <source>AG123</source>
             <sendTime>01:02:03</sendTime>
@@ -83,7 +82,7 @@ but they are commonly needed so we have them here for future convenience.
     </document>
     <errors>
       <error>Parse Error</error>
-      <error>Choice dispatch key (P) failed to match any of the branch keys</error>
+      <error>Choice dispatch key (80) failed to match any of the branch keys</error>
     </errors>
   </parserTestCase>
 
@@ -134,7 +133,6 @@ but they are commonly needed so we have them here for future convenience.
     <infoset>
       <dfdlInfoset>
         <fakeTDL xmlns="">
-          <messageType>T</messageType>
           <track>
             <source>AG12Z</source>
             <sendTime>01:02:03</sendTime>

--- a/test/test_file_01.xml
+++ b/test/test_file_01.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fakeTDLFile>
   <fakeTDL>
-    <messageType>T</messageType>
     <track>
       <source>AG123</source>
       <sendTime>01:02:03</sendTime>
@@ -22,7 +21,6 @@
     </track>
   </fakeTDL>
   <fakeTDL>
-    <messageType>D</messageType>
     <identity>
       <source>AG123</source>
       <sendTime>01:02:04</sendTime>
@@ -37,7 +35,6 @@
     </identity>
   </fakeTDL>
   <fakeTDL>
-    <messageType>A</messageType>
     <ack>
       <source>BE234</source>
       <sendTime>01:02:14</sendTime>

--- a/test/test_msg_01.xml
+++ b/test/test_msg_01.xml
@@ -1,5 +1,4 @@
 <fakeTDL>
-  <messageType>T</messageType>
   <track>
     <source>AG123</source>
     <sendTime>01:02:03</sendTime>

--- a/test/test_msg_bad_02.xml
+++ b/test/test_msg_bad_02.xml
@@ -1,5 +1,4 @@
 <fakeTDL>
-  <messageType>T</messageType>
   <track>
     <source>AG123</source>
     <sendTime>25:99</sendTime>


### PR DESCRIPTION
This cleans up a problem of the `<messageType>T</messageType>` element potentially being modified to not match the following `<track>...</track>` element. 

There is no longer a `messageType` element that can mismatch. We just `dfdlx:lookAhead(0,8)` at the byte that is the initiator, and then each branch actually consumes that byte as an initiator (and lays down that initiator value when unparsing.)

This is a by-hand roll-your-own way to achieve what we'd like Daffodil to do as an optimization when it encounters
a choice with `dfdl:initiatedContent="yes"` and all branches have` dfdl:initiator` values which are constant strings of the same fixed length. 

